### PR TITLE
Make highlight group matching case insensitive when disabling

### DIFF
--- a/autoload/highlighturl.vim
+++ b/autoload/highlighturl.vim
@@ -55,7 +55,7 @@ endfunction
 
 function! highlighturl#delete_url_match() abort
   for m in getmatches()
-    if m.group ==# 'HighlightUrl' || m.group ==# 'HighlightUrlCursor'
+    if m.group ==? 'HighlightUrl' || m.group ==? 'HighlightUrlCursor'
       call matchdelete(m.id)
     endif
   endfor


### PR DESCRIPTION
I am using this plugin with Neovim and for some reason the matching groups when they are added are being added as `HighlightURL` instead of `HighlightUrl` so the case sensitivity breaks the disable function. Could we possibly make the checking here case insensitive for this situation? 

Resolves #6 